### PR TITLE
skytomo patch

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import sys
+from collections import namedtuple
 
 import discord
 import jpholiday
@@ -12,6 +13,12 @@ import data_shirase
 client = discord.Client()
 channel_id = data_shirase.channel_id()
 mention_id = "<@&"+str(data_shirase.role_id())+"> "
+
+Timetables = namedtuple('Timetables', ('weekends_and_holidays', 'weekdays'))
+timetables = Timetables(
+    weekends_and_holidays=['0850', '1700'],
+    weekdays=['0730', '1253', '1750', '2100']
+)
 
 
 @client.event
@@ -56,10 +63,10 @@ async def loop():
     date = datetime.datetime.now().strftime('%Y%m%d')
     time = datetime.datetime.now().strftime('%H%M')
     if is_weekend_or_holiday(weekday, date):
-        if time == '0850' or time == '1700':  # 土日
+        if time in timetables.weekends_and_holidays:  # 土日
             channel = client.get_channel(channel_id)
             await channel.send(url(date, time))
-    elif time == '0730' or time == '1253' or time == '1750' or time == '2100':  # 平日
+    elif time in timetables.weekdays:  # 平日
         channel = client.get_channel(channel_id)
         await channel.send(url(date, time))
 loop.start()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, time
 
 import discord
 import jpholiday
@@ -16,8 +16,8 @@ mention_id = "<@&"+str(data_shirase.role_id())+"> "
 
 Timetables = namedtuple('Timetables', ('weekends_and_holidays', 'weekdays'))
 timetables = Timetables(
-    weekends_and_holidays=['0850', '1700'],
-    weekdays=['0730', '1253', '1750', '2100']
+    weekends_and_holidays=[time(8, 50), time(17)],
+    weekdays=[time(7, 30), time(12, 53), time(17, 50), time(21)]
 )
 
 
@@ -58,10 +58,10 @@ def url(datetime):
 
 @tasks.loop(seconds=60)
 async def loop():
-    now = datetime.now()
+    now = datetime.now().replace(second=0, microsecond=0)
     timetable = timetables.weekends_and_holidays if is_weekend_or_holiday(
         now) else timetables.weekdays
-    if now.strftime('%H%M') in timetable:
+    if now.time() in timetable:
         channel = client.get_channel(channel_id)
         await channel.send(mention_id + url(now))
 loop.start()

--- a/main.py
+++ b/main.py
@@ -42,10 +42,7 @@ async def on_message(message):
 
 
 def is_weekend_or_holiday(weekday, date):
-    if weekday >= 5 or jpholiday.is_holiday(date):
-        return 1
-    else:
-        return 0
+    return weekday >= 5 or jpholiday.is_holiday(date)
 
 
 def url(date, time):
@@ -58,7 +55,7 @@ async def loop():
     weekday = datetime.date.today().weekday()
     date = datetime.datetime.now().strftime('%Y%m%d')
     time = datetime.datetime.now().strftime('%H%M')
-    if is_weekend_or_holiday(weekday, date) == 1:
+    if is_weekend_or_holiday(weekday, date):
         if time == '0850' or time == '1700':  # 土日
             channel = client.get_channel(channel_id)
             await channel.send(url(date, time))

--- a/main.py
+++ b/main.py
@@ -48,8 +48,8 @@ async def on_message(message):
         await message.channel.send(reply)  # reply
 
 
-def is_weekend_or_holiday(weekday, date):
-    return weekday >= 5 or jpholiday.is_holiday(date)
+def is_weekend_or_holiday(datetime):
+    return datetime.weekday() >= 5 or jpholiday.is_holiday(datetime.date())
 
 
 def url(date, time):
@@ -59,11 +59,11 @@ def url(date, time):
 
 @tasks.loop(seconds=60)
 async def loop():
-    weekday = datetime.date.today().weekday()
-    date = datetime.datetime.now().strftime('%Y%m%d')
-    time = datetime.datetime.now().strftime('%H%M')
+    now = datetime.datetime.now()
+    date = now.strftime('%Y%m%d')
+    time = now.strftime('%H%M')
     timetable = timetables.weekends_and_holidays if is_weekend_or_holiday(
-        weekday, date) else timetables.weekdays
+        now) else timetables.weekdays
     if time in timetable:
         channel = client.get_channel(channel_id)
         await channel.send(url(date, time))

--- a/main.py
+++ b/main.py
@@ -52,21 +52,18 @@ def is_weekend_or_holiday(datetime):
     return datetime.weekday() >= 5 or jpholiday.is_holiday(datetime.date())
 
 
-def url(date, time):
-    url = mention_id + "https://radiko.jp/#!/ts/RN1/" + date + time + "00"
-    return url
+def url(datetime):
+    return datetime.strftime("https://radiko.jp/#!/ts/RN1/%Y%m%d%H%M00")
 
 
 @tasks.loop(seconds=60)
 async def loop():
     now = datetime.datetime.now()
-    date = now.strftime('%Y%m%d')
-    time = now.strftime('%H%M')
     timetable = timetables.weekends_and_holidays if is_weekend_or_holiday(
         now) else timetables.weekdays
-    if time in timetable:
+    if now.strftime('%H%M') in timetable:
         channel = client.get_channel(channel_id)
-        await channel.send(url(date, time))
+        await channel.send(mention_id + url(now))
 loop.start()
 
 

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ async def on_message(message):
         await message.channel.send(reply)  # reply
 
 
-def is_holyday(weekday, date):
+def is_holiday(weekday, date):
     if weekday >= 5 or jpholiday.is_holiday(date):
         return 1
     else:
@@ -55,7 +55,7 @@ async def loop():
     weekday = datetime.date.today().weekday()
     date = datetime.datetime.now().strftime('%Y%m%d')
     time = datetime.datetime.now().strftime('%H%M')
-    if is_holyday(weekday, date) == 1:
+    if is_holiday(weekday, date) == 1:
         if time == '0850' or time == '1700':  # 土日
             channel = client.get_channel(channel_id)
             await channel.send(url(date, time))

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ async def on_message(message):
         await message.channel.send(reply)  # reply
 
 
-def is_holiday(weekday, date):
+def is_weekend_or_holiday(weekday, date):
     if weekday >= 5 or jpholiday.is_holiday(date):
         return 1
     else:
@@ -58,7 +58,7 @@ async def loop():
     weekday = datetime.date.today().weekday()
     date = datetime.datetime.now().strftime('%Y%m%d')
     time = datetime.datetime.now().strftime('%H%M')
-    if is_holiday(weekday, date) == 1:
+    if is_weekend_or_holiday(weekday, date) == 1:
         if time == '0850' or time == '1700':  # 土日
             channel = client.get_channel(channel_id)
             await channel.send(url(date, time))

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
-import datetime
 import os
 import sys
 from collections import namedtuple
+from datetime import datetime
 
 import discord
 import jpholiday
@@ -58,7 +58,7 @@ def url(datetime):
 
 @tasks.loop(seconds=60)
 async def loop():
-    now = datetime.datetime.now()
+    now = datetime.now()
     timetable = timetables.weekends_and_holidays if is_weekend_or_holiday(
         now) else timetables.weekdays
     if now.strftime('%H%M') in timetable:

--- a/main.py
+++ b/main.py
@@ -62,11 +62,9 @@ async def loop():
     weekday = datetime.date.today().weekday()
     date = datetime.datetime.now().strftime('%Y%m%d')
     time = datetime.datetime.now().strftime('%H%M')
-    if is_weekend_or_holiday(weekday, date):
-        if time in timetables.weekends_and_holidays:  # 土日
-            channel = client.get_channel(channel_id)
-            await channel.send(url(date, time))
-    elif time in timetables.weekdays:  # 平日
+    timetable = timetables.weekends_and_holidays if is_weekend_or_holiday(
+        weekday, date) else timetables.weekdays
+    if time in timetable:
         channel = client.get_channel(channel_id)
         await channel.send(url(date, time))
 loop.start()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
-import jpholiday
-import discord
-from discord.ext import tasks
 import datetime
-import os,sys
+import os
+import sys
+
+import discord
+import jpholiday
+from discord.ext import tasks
+
 sys.path.append(os.pardir)
 import data_shirase
 

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ async def on_message(message):
 
 
 def is_weekend_or_holiday(datetime):
-    return datetime.weekday() >= 5 or jpholiday.is_holiday(datetime.date())
+    return datetime.weekday() >= 5 or jpholiday.is_holiday(datetime)
 
 
 def url(datetime):


### PR DESCRIPTION
コミットごとにコメントを残しておきますね～

## typo fix

`is_holyday` を `is_holiday` に変更

## sort import

import文を書く順序があるらしいです…

[Pythonでimport文を書く際の順番](https://qiita.com/ryooku/items/385f42a627039d6209ad)
[すべてのPythonistaに知ってほしいimport順序をプロジェクト内で統一させる方法](https://qiita.com/tez/items/5c9a42b075d75d4a5aac)
[Pythonのimport文の並び順のフォーマットについて【isort】](https://kamatimaru.hatenablog.com/entry/2020/04/28/153423)

ところで、親ディレクトリに`data_shirase.py`を作成するのではなく、カレントディレクトリに置くのはダメなのですか？

## rename to is_weekend_or_holiday

`is_holiday`だと`jpholiday.is_holiday`と混乱しそうなので

## change is_weekend_or_holiday return type to 'bool'

Pythonにはboolがあるのでそっちのほうが簡潔だと思います

## add timetables

最初に定義しておけば、後から変更するときに楽だよね、ってやつ  
あと、`in`演算子が使えて便利

## refactor timetable

```python
    timetable = None
    if is_weekend_or_holiday(weekday, date):
        timetable = timetables.weekends_and_holidays
    else:
        timetable = timetables.weekdays
```

ちなみにこう書くのも手
（本当はPythonの三項演算子あんまり好きじゃないので）

## change is_weekend_or_holiday argument type to 'datetime'

datetime型1個渡せばできる処理なので変更しました

## change url

上と同じく…

あと関数名がurlなので、URLだけ返す関数でないと少しおかしい気がしたので、mention_idを追い出しました。

## code golf

`.date()`する必要なかった…

## change to 'from datetime import datetime'

少し見やすくなる

## change timetables type to 'time'

こう書くことで、
例えばうっかり`time(123, 53)`と書こうものなら

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: hour must be in 0..23
```

と怒ってくれます。
あと、`'0850'`と書かれていた場合はきっと8時50分だろうなというのは察せるし、読んでいるうちに分かりますが、`time(8, 50)`なら確実に8時50分であることを意味し、初見でもこれを読んだ時点で分かります。

